### PR TITLE
refactor: Modify alert style

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -114,7 +114,7 @@
         </div>
       </div>
       <% if notice %>
-        <div class="alert alert-primary alert-dismissible fade show alert-position container" role="alert">
+        <div class="alert alert-primary alert-dismissible fade show container mt-3 mb-3 mr-auto ml-auto" role="alert">
           <%= notice %>
           <button type="button" class="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>


### PR DESCRIPTION
close https://github.com/jungissei/meal-share/issues/62

## 概要

- アラートがコンテンツに被って表示されてしまうので、被らないように修正

## 修正内容の検証方法
下記のコマンド実行後、投稿実行後に表示されるアラートの表示がコンテンツに被っていないか確認
```
$ docker-compose up -d
```

## この修正が正しい理由
テスト環境にて投稿を行い、コンテンツが被っていないことを確認
