### PR TITLE
refactor: Modify sign up form #70

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   protected
     def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :email, :password, :password_confirmation, :image, :name])
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :email, :password, :password_confirmation])
       devise_parameter_sanitizer.permit(:sign_in, keys: [:login, :password, :password_confirmation, :remember_me])
       devise_parameter_sanitizer.permit(:account_update, keys: [:username, :email, :password, :password_confirmation, :current_password, :image, :image_cache, :name])
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,8 @@ class User < ApplicationRecord
 
   attr_accessor :login
 
+  validates :email, uniqueness: true
+  validates :username, presence: true, uniqueness: true
   validate :password_complexity
 
   def login

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,7 +7,7 @@
       <tbody>
         <tr>
           <td>
-            <div class="table-form__field-name mb-2"><%= f.label :username, 'ユーザーID' %></div>
+            <div class="table-form__field-name mb-2 require"><%= f.label :username, 'ユーザーID' %></div>
             <div class="form-file custom-file">
               <%= f.text_field :username, class:'form-control', placeholder:'ユーザーID' %>
             </div>
@@ -18,25 +18,6 @@
             <div class="table-form__field-name mb-2 require"><%= f.label :email, 'メールアドレス' %></div>
             <div class="form-file custom-file">
               <%= f.email_field :email, autofocus: true, autocomplete: 'email', class:'form-control', placeholder:'メールアドレス' %>
-            </div>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <div class="table-form__field-name mb-2"><%= f.label :image, 'ユーザー画像' %></div>
-            <div class="form-file custom-file">
-              <%= f.file_field :image, class:'form-file-input custom-file-input' %>
-              <%= f.label :image, class:'form-file-label custom-file-label' do %>
-                <span class="form-file-text">画像を選択</span>
-              <% end %>
-            </div>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <div class="table-form__field-name mb-2"><%= f.label :name, 'ハンドルネーム' %></div>
-            <div class="form-file custom-file">
-              <%= f.text_field :name, class:'form-control', placeholder:'ハンドルネーム' %>
             </div>
           </td>
         </tr>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -7,6 +7,7 @@ ja:
         password: "パスワード"
         password_confirmation: "確認用パスワード"
         remember_me: "ログインを記憶"
+        username: "ユーザーID"
     models:
       user: "ユーザ"
   devise:
@@ -69,35 +70,35 @@ ja:
     distance_in_words:
       half_a_minute: "30秒前後"
       less_than_x_seconds:
-        one:   "1秒"
+        one: "1秒"
         other: "%{count}秒"
       x_seconds:
-        one:   "1秒"
+        one: "1秒"
         other: "%{count}秒"
       less_than_x_minutes:
-        one:   "1分"
+        one: "1分"
         other: "%{count}分"
       x_minutes:
-        one:   "約1分"
+        one: "約1分"
         other: "%{count}分"
       about_x_hours:
-        one:   "約1時間"
+        one: "約1時間"
         other: "約%{count}時間"
       x_days:
-        one:   "1日"
+        one: "1日"
         other: "%{count}日"
       about_x_months:
-        one:   "約1ヶ月"
+        one: "約1ヶ月"
         other: "約%{count}ヶ月"
       x_months:
-        one:   "1ヶ月"
+        one: "1ヶ月"
         other: "%{count}ヶ月"
       almost_x_years:
-        one:   "１年弱"
+        one: "１年弱"
         other: "%{count}年弱"
       about_x_years:
-        one:   "約1年"
+        one: "約1年"
         other: "約%{count}年"
       over_x_years:
-        one:   "1年以上"
+        one: "1年以上"
         other: "%{count}年以上"


### PR DESCRIPTION
close #70

## 概要

- 会員登録フォームを「ユーザーID」「メールアドレス」「パスワード」「パスワード確認用」のみする。フォーム簡潔化。

## 修正内容の検証方法

会員登録を行う

## この修正が正しい理由

会員登録を行った結果、正常に会員登録が出来たことを確認した。