### PR TITLE
fix: Remove local SSL setting #102

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -200,18 +200,21 @@ img {
   }
 
   .simple__thumb {
+    position: relative;
+    overflow: hidden;
+    height: 55px;
+
+    @include mq("md") {
+      height: 142px;
+    }
+
+    @include mq("lg") {
+      height: 80px;
+    }
+
     img {
       width: 100%;
-      height: 55px;
       object-fit: cover;
-
-      @include mq("md") {
-        height: 142px;
-      }
-
-      @include mq("lg") {
-        height: 80px;
-      }
     }
   }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,13 +37,8 @@ services:
       - "443:443"
     volumes:
       - sockets:/app/tmp/sockets
-      - ./docker/nginx/ssl:/etc/nginx/ssl
     depends_on:
       - app
-    # command: /bin/sh -c "envsubst '$$SSL_CERTIFICATE_PATH $$SSL_CERTIFICATE_KEY_PATH'< /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
-    environment:
-      SSL_CERTIFICATE_PATH: /etc/nginx/ssl/server.crt
-      SSL_CERTIFICATE_KEY_PATH: /etc/nginx/ssl/server.key
 
 volumes:
   db_data:

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,10 +1,14 @@
 FROM nginx:1.16
-RUN apt-get update && \
-  apt-get install -y apt-utils \
-  locales && \
-  echo "ja_JP.UTF-8 UTF-8" > /etc/locale.gen && \
-  locale-gen ja_JP.UTF-8
+
+RUN apt-get update && apt-get install --no-install-recommends -y python \
+  -y apt-utils \
+  locales\
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && echo "ja_JP.UTF-8 UTF-8" > /etc/locale.gen \
+  && locale-gen ja_JP.UTF-8
+
 ENV LC_ALL ja_JP.UTF-8
 # 初期状態の設定ファイル
-ADD ./docker/nginx/nginx.conf /etc/nginx/nginx.conf
-ADD ./docker/nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY ./docker/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY ./docker/nginx/default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
close #102

## 概要

- ローカル環境の不要なSSL関連設定ファイル、記述削除

## 修正内容の検証方法

- アプリケーションを`rails s`コマンドを実行して、`localhost:3000`にアクセス

## この修正が正しい理由

- ローカル環境で正常に表示されることを確認済み